### PR TITLE
rewrite headers so that we can have request cookies

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,7 +35,10 @@ pub fn build(b: *std.Build) !void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
 
-    const examples = [_][]const u8{"basic"};
+    const examples = [_][]const u8{
+        "basic",
+        "cookies",
+    };
     for (examples) |example| {
         const path = try std.fmt.allocPrint(b.allocator, "examples/{s}.zig", .{example});
         const example_exe = b.addExecutable(.{

--- a/examples/cookies.zig
+++ b/examples/cookies.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Verse = @import("verse");
 const Router = Verse.Router;
 const BuildFn = Router.BuildFn;
+const print = std.fmt.bufPrint;
 
 const routes = [_]Router.Match{
     Router.GET("", index),
@@ -12,7 +13,7 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
 
-    var server = try Verse.Server.init(alloc, .{ .http = .{ .port = 8080 } }, .{ .routefn = route });
+    var server = try Verse.Server.init(alloc, .{ .http = .{ .port = 8081 } }, .{ .routefn = route });
 
     server.serve() catch |err| {
         std.debug.print("error: {any}", .{err});
@@ -25,6 +26,8 @@ fn route(verse: *Verse) Router.Error!BuildFn {
 }
 
 fn index(verse: *Verse) Router.Error!void {
+    var buffer: [2048]u8 = undefined;
+    const found = try print(&buffer, "{} cookies found by the server\n", .{verse.request.cookie_jar.cookies.items.len});
     try verse.quickStart();
-    try verse.sendRawSlice("hello world");
+    try verse.sendRawSlice(found);
 }

--- a/src/headers.zig
+++ b/src/headers.zig
@@ -2,50 +2,113 @@ const std = @import("std");
 
 const Allocator = std.mem.Allocator;
 
-pub const HIndex = std.StringHashMap(Value);
-
-const Value = struct {
-    str: []const u8,
-    next: ?*Value = null,
-};
-
 pub const Headers = @This();
 
+const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+const ValueList = struct {
+    value: []const u8,
+    next: ?*ValueList = null,
+};
+
+const HeaderMap = std.StringArrayHashMap(*ValueList);
+
 alloc: Allocator,
-index: HIndex,
+headers: HeaderMap,
 
 pub fn init(a: Allocator) Headers {
     return .{
         .alloc = a,
-        .index = HIndex.init(a),
+        .headers = HeaderMap.init(a),
     };
 }
 
 pub fn raze(h: *Headers) void {
-    h.index.deinit(h.alloc);
-    h.* = undefined;
+    const values = h.headers.values();
+    for (values) |val| {
+        var next: ?*ValueList = val.*.next;
+        h.alloc.destroy(val);
+        while (next != null) {
+            const destroy = next.?;
+            next = next.?.next;
+            h.alloc.destroy(destroy);
+        }
+    }
+    h.headers.deinit();
 }
 
-/// TODO actually normalize to thing
-/// TODO are we gonna normilize comptime?
-fn normilize(name: []const u8) !void {
-    if (name.len == 0) return;
+fn normalize(_: []const u8) !void {
+    comptime unreachable;
 }
 
-pub fn add(h: *Headers, comptime name: []const u8, value: []const u8) !void {
-    try normilize(name);
-    const res = try h.index.getOrPut(name);
-    if (res.found_existing) {
-        res.value_ptr.* = Value{
-            .str = value,
-            .next = res.value_ptr,
-        };
+pub fn add(h: *Headers, name: []const u8, value: []const u8) !void {
+    // TODO normalize lower
+    const gop = try h.headers.getOrPut(name);
+    if (gop.found_existing) {
+        var end: *ValueList = gop.value_ptr.*;
+        while (end.*.next != null) {
+            end = end.next.?;
+        }
+        end.next = try h.alloc.create(ValueList);
+        end.next.?.value = value;
+        end.next.?.next = null;
     } else {
-        res.value_ptr.* = Value{
-            .str = value,
-        };
+        gop.value_ptr.* = try h.alloc.create(ValueList);
+        gop.value_ptr.*.value = value;
+        gop.value_ptr.*.next = null;
     }
 }
+
+/// Starting an iteration will lock the map pointers, callers must complete the
+/// iteration, or manually unlock internal pointers. See also: Iterator.finish();
+pub fn iterator(h: *Headers) Iterator {
+    return Iterator.init(h);
+}
+
+pub const Iterator = struct {
+    header: *Headers,
+    inner: HeaderMap.Iterator,
+    entry: ?HeaderMap.Entry = null,
+    current: ?*ValueList = null,
+    current_name: ?[]const u8 = null,
+
+    pub fn init(h: *Headers) Iterator {
+        h.headers.lockPointers();
+        return .{
+            .header = h,
+            .inner = h.headers.iterator(),
+        };
+    }
+
+    pub fn next(i: *Iterator) ?Header {
+        if (i.current) |current| {
+            defer i.current = current.next;
+            return .{
+                .name = i.current_name.?,
+                .value = current.value,
+            };
+        } else {
+            i.current_name = null;
+            i.entry = i.inner.next();
+            if (i.entry) |entry| {
+                i.current = entry.value_ptr.*;
+                i.current_name = entry.key_ptr.*;
+            } else {
+                i.header.headers.unlockPointers();
+                return null;
+            }
+            return i.next();
+        }
+    }
+
+    /// Helper
+    pub fn finish(i: *Iterator) void {
+        while (i.next()) |_| {}
+    }
+};
 
 pub fn format(h: Headers, comptime _: []const u8, _: std.fmt.FormatOptions, out: anytype) !void {
     _ = h;
@@ -53,6 +116,20 @@ pub fn format(h: Headers, comptime _: []const u8, _: std.fmt.FormatOptions, out:
     unreachable;
 }
 
-pub fn clearAndFree(h: *Headers) void {
-    h.index.clearAndFree(h.alloc);
+test Headers {
+    const a = std.testing.allocator;
+    var hmap = init(a);
+    defer hmap.raze();
+    try hmap.add("first", "1");
+    try hmap.add("first", "2");
+    try hmap.add("first", "3");
+    try hmap.add("second", "4");
+
+    try std.testing.expectEqual(2, hmap.headers.count());
+    const first = hmap.headers.get("first");
+    try std.testing.expectEqualStrings(first.?.value, "1");
+    try std.testing.expectEqualStrings(first.?.next.?.value, "2");
+    try std.testing.expectEqualStrings(first.?.next.?.next.?.value, "3");
+    const second = hmap.headers.get("second");
+    try std.testing.expectEqualStrings(second.?.value, "4");
 }

--- a/src/http.zig
+++ b/src/http.zig
@@ -50,7 +50,7 @@ pub fn serve(http: *HTTP) !void {
         const a = arena.allocator();
 
         var hreq = try hsrv.receiveHead();
-        var req = try Request.init(a, &hreq);
+        var req = try Request.initHttp(a, &hreq);
         var ipbuf: [0x20]u8 = undefined;
         const ipport = try std.fmt.bufPrint(&ipbuf, "{}", .{conn.address});
         if (std.mem.indexOfScalar(u8, ipport, ':')) |i| {
@@ -69,10 +69,10 @@ pub fn serve(http: *HTTP) !void {
 fn buildVerse(a: Allocator, req: *Request) !Verse {
     var itr_headers = req.raw.http.iterateHeaders();
     while (itr_headers.next()) |header| {
-        log.debug("http header => {s} -> {s}\n", .{ header.name, header.value });
+        log.debug("http header => {s} -> {s}", .{ header.name, header.value });
         log.debug("{}", .{header});
     }
-    log.debug("http target -> {s}\n", .{req.uri});
+    log.debug("http target -> {s}", .{req.uri});
     var post_data: ?RequestData.PostData = null;
     var reqdata: RequestData = undefined;
 

--- a/src/request.zig
+++ b/src/request.zig
@@ -3,9 +3,19 @@ const Allocator = std.mem.Allocator;
 const indexOf = std.mem.indexOf;
 const eql = std.mem.eql;
 
+const Headers = @import("headers.zig");
+const Cookies = @import("cookies.zig");
+
 const zWSGIRequest = @import("zwsgi.zig").zWSGIRequest;
 
 pub const Request = @This();
+
+/// TODO this is unstable and likely to be removed
+raw: RawReq,
+headers: Headers,
+uri: []const u8,
+method: Methods,
+cookie_jar: Cookies.Jar,
 
 pub const RawReq = union(enum) {
     zwsgi: *zWSGIRequest,
@@ -16,8 +26,6 @@ const Pair = struct {
     name: []const u8,
     val: []const u8,
 };
-
-pub const HeaderList = std.ArrayList(Pair);
 
 pub const Methods = enum(u8) {
     GET = 1,
@@ -39,56 +47,49 @@ pub const Methods = enum(u8) {
     }
 };
 
-/// TODO this is unstable and likely to be removed
-raw: RawReq,
-headers: HeaderList,
-uri: []const u8,
-method: Methods,
-
-pub fn init(a: Allocator, raw_req: anytype) !Request {
-    switch (@TypeOf(raw_req)) {
-        *zWSGIRequest => {
-            var req = Request{
-                .raw = .{ .zwsgi = raw_req },
-                .headers = HeaderList.init(a),
-                .uri = undefined,
-                .method = Methods.GET,
-            };
-            for (raw_req.vars) |v| {
-                try req.addHeader(v.key, v.val);
-                if (std.mem.eql(u8, v.key, "PATH_INFO")) {
-                    req.uri = v.val;
-                }
-                if (std.mem.eql(u8, v.key, "REQUEST_METHOD")) {
-                    req.method = Methods.fromStr(v.val) catch Methods.GET;
-                }
-            }
-            return req;
-        },
-        *std.http.Server.Request => {
-            var req = Request{
-                .raw = .{ .http = raw_req },
-                .headers = HeaderList.init(a),
-                .uri = raw_req.head.target,
-                .method = switch (raw_req.head.method) {
-                    .GET => .GET,
-                    .POST => .POST,
-                    else => @panic("not implemented"),
-                },
-            };
-            var itr = raw_req.iterateHeaders();
-            while (itr.next()) |head| {
-                try req.addHeader(head.name, head.value);
-            }
-            return req;
-        },
-        else => @compileError("rawish of " ++ @typeName(raw_req) ++ " isn't a support request type"),
+pub fn initZWSGI(a: Allocator, zwsgi: *zWSGIRequest) !Request {
+    var req = Request{
+        .raw = .{ .zwsgi = zwsgi },
+        .headers = Headers.init(a),
+        .uri = undefined,
+        .method = Methods.GET,
+        .cookie_jar = undefined,
+    };
+    for (zwsgi.vars) |v| {
+        try req.addHeader(v.key, v.val);
+        if (eql(u8, v.key, "PATH_INFO")) {
+            req.uri = v.val;
+        }
+        if (eql(u8, v.key, "REQUEST_METHOD")) {
+            req.method = Methods.fromStr(v.val) catch Methods.GET;
+        }
     }
-    @compileError("unreachable");
+    req.cookie_jar = try Cookies.Jar.initFromHeaders(a, &req.headers);
+    return req;
+}
+
+pub fn initHttp(a: Allocator, http: *std.http.Server.Request) !Request {
+    var req = Request{
+        .raw = .{ .http = http },
+        .headers = Headers.init(a),
+        .uri = http.head.target,
+        .method = switch (http.head.method) {
+            .GET => .GET,
+            .POST => .POST,
+            else => @panic("not implemented"),
+        },
+        .cookie_jar = undefined,
+    };
+    var itr = http.iterateHeaders();
+    while (itr.next()) |head| {
+        try req.addHeader(head.name, head.value);
+    }
+    req.cookie_jar = try Cookies.Jar.initFromHeaders(a, &req.headers);
+    return req;
 }
 
 pub fn addHeader(self: *Request, name: []const u8, val: []const u8) !void {
-    try self.headers.append(.{ .name = name, .val = val });
+    try self.headers.add(name, val);
 }
 
 pub fn getHeader(self: Request, key: []const u8) ?[]const u8 {

--- a/src/zwsgi.zig
+++ b/src/zwsgi.zig
@@ -89,7 +89,7 @@ pub fn serve(z: *zWSGI) !void {
         const a = arena.allocator();
 
         var zreq = try readHeader(a, &acpt);
-        var request = try Request.init(a, &zreq);
+        var request = try Request.initZWSGI(a, &zreq);
         var verse = try buildVerse(a, &request);
 
         defer {


### PR DESCRIPTION
just pushed a single commit here which arguably should have split in to multiple commits, but uh.... `lmao git rekt nub`?

but I'm actually mentioning it more because I did have to change `example/basic.zig`. It "shouldn't" have worked the way it was written, and I unintentionally fixed it here.

I think this change is better codewise, but worse from lib robustness, I'm thinking it's probably best to re-wrap all the sending code in a protective layer to ensure that 
1) headers aren't changed after they're sent, and 
2) that you can't send data before sending complete headers

I didn't and left it open for comments because I wanted to give it a bit more thought before doing something simple like `if (response.state == headers or state == content)` or whatever.