### PR TITLE
add the ability to inject data

### DIFF
--- a/src/template.zig
+++ b/src/template.zig
@@ -12,7 +12,7 @@ pub const Directive = @import("template/directive.zig");
 pub const DOM = @import("dom.zig");
 pub const HTML = @import("html.zig");
 
-const Pages = @import("template/page.zig");
+pub const Pages = @import("template/page.zig");
 pub const Page = Pages.Page;
 pub const PageRuntime = Pages.PageRuntime;
 

--- a/src/verse.zig
+++ b/src/verse.zig
@@ -27,6 +27,7 @@ uri: UriIter,
 // TODO fix this unstable API
 auth: Auth,
 route_ctx: ?*const anyopaque = null,
+page_injector: ?*const fn (*anyopaque, []const u8) ?[]const u8 = null,
 
 // Raw move from response.zig
 headers: Headers,
@@ -226,16 +227,13 @@ pub fn redirect(vrs: *Verse, loc: []const u8, see_other: bool) !void {
 /// sendPage will flush headers to the client before sending Page data
 pub fn sendPage(vrs: *Verse, page: anytype) NetworkError!void {
     try vrs.quickStart();
-    const loggedin = if (vrs.auth.valid()) "<a href=\"#\">Logged In</a>" else "Public";
-    const T = @TypeOf(page.*);
-    if (@hasField(T, "data") and @hasField(@TypeOf(page.data), "body_header")) {
-        page.data.body_header.?.nav.?.nav_auth = loggedin;
-    }
+
+    const inj: ?Template.Pages.Injector = if (vrs.page_injector) |pj| .{ .ctx = vrs, .func = pj } else null;
 
     switch (vrs.downstream) {
         .http, .zwsgi => |stream| {
             const w = stream.writer();
-            page.format("{}", .{}, w) catch |err| switch (err) {
+            page.format2("{}", inj, w) catch |err| switch (err) {
                 else => log.err("Page Build Error {}", .{err}),
             };
         },


### PR DESCRIPTION
This is just wrong, but it's the first pass of where I actually should belong which is to expose this internall only. Verse should provide the API that endpoints can use to fetch this data themselves before editing the page.

The real fix for this will include making page.data const so once a page is 'prepared' it can be modified.

My only regret is that I didn't see that before now... fix coming

(real target branch is main, but I don't wanna cherry pick)