### PR TITLE
scope templates by default

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -202,7 +202,7 @@ fn requestData(a: Allocator, req: *std.http.Server.Request) !Request.Data {
 }
 
 fn threadFn(server: *HTTP, gpa: Allocator, io: Io) void {
-    var srv = server.srv_address.listen(io, .{}) catch unreachable;
+    var srv = server.srv_address.listen(io, .{ .reuse_address = true }) catch unreachable;
     defer srv.deinit(io);
     var stream = srv.accept(io) catch unreachable;
 

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -177,7 +177,7 @@ pub const Endpoint = struct {
             .open => include_ip = true,
         }
 
-        var data: [60]S.VerseStatsList = @splat(
+        var data: [60]S.VerseStatsHtml.VerseStatsList = @splat(
             .{
                 .code = 500,
                 .ip_address = "",

--- a/src/template/directive.zig
+++ b/src/template/directive.zig
@@ -5,8 +5,9 @@ tag_block: []const u8,
 tag_block_body: ?[]const u8 = null,
 tag_block_skip: ?usize = null,
 html_type: ?HtmlType = null,
+scope: Scope = .local,
 
-pub const Directive = @This();
+const Directive = @This();
 
 pub const Otherwise = union(enum) {
     required: void,
@@ -46,15 +47,13 @@ pub const HtmlType = enum {
     }
 
     pub fn nullable(kt: HtmlType) bool {
-        return switch (kt) {
-            .usize,
-            .isize,
-            .@"enum",
-            .humanize,
-            => false,
-            .@"?usize" => true,
-        };
+        return @tagName(kt)[0] == '?';
     }
+};
+
+pub const Scope = enum {
+    local,
+    global,
 };
 
 pub fn init(str: []const u8) ?Directive {
@@ -251,13 +250,22 @@ fn findTag(blob: []const u8) ![]const u8 {
 }
 
 pub const TagAttribute = enum {
+    /// adds the specified string to the generate enum
     @"enum",
+    /// Provides default text for <Tags>
     default,
+    /// Use a comptime known length and array
     exact,
+    /// Used in <Directives>, specifies the name for the following tags
     name,
+    /// Used in <Directives>, specifies the text returned for the given/active tag
     text,
+    /// Use supported zig type
     type,
+    /// Use a builtin template for the "body" of this tag
     use,
+    /// Defines the scope for the tag body, either global or local
+    scope,
 };
 
 pub const TagAttrMap = std.EnumMap(TagAttribute, []const u8);


### PR DESCRIPTION
before
```zig
pub const VerseStatsList = struct {
    status_class: []const u8,
    is_bot: ?[]const u8 = null,
    number: usize,
    time: usize,
    ip_address: []const u8,
    code_string: ?[]const u8 = null,
    code: usize,
    uri: []const u8,
    page_size: usize,
    rss: usize,
    us: usize,
    user_agent_name: []const u8,
    user_agent_version: ?usize,

    pub const translate = AutoTranslate(@This()).translate;
    pub const translateAlloc = AutoTranslate(@This()).translateAlloc;
};
// ...
pub const VerseStatsHtml = struct {
    uptime: usize,
    count: usize,
    mean_resp_time: usize,
    verse_stats_list: []const VerseStatsList,

    pub const translate = AutoTranslate(@This()).translate;
    pub const translateAlloc = AutoTranslate(@This()).translateAlloc;
};
```

after 

```zig
pub const VerseStatsHtml = struct {
    uptime: usize,
    count: usize,
    mean_resp_time: usize,
    verse_stats_list: []const VerseStatsList,

    pub const translate = AutoTranslate(@This()).translate;
    pub const translateAlloc = AutoTranslate(@This()).translateAlloc;
    pub const VerseStatsList = struct {
        status_class: []const u8,
        is_bot: ?[]const u8 = null,
        number: usize,
        time: usize,
        ip_address: []const u8,
        code_string: ?[]const u8 = null,
        code: usize,
        uri: []const u8,
        page_size: usize,
        rss: usize,
        us: usize,
        user_agent_name: []const u8,
        user_agent_version: ?usize,

        pub const translate = AutoTranslate(@This()).translate;
        pub const translateAlloc = AutoTranslate(@This()).translateAlloc;
    };
};


```